### PR TITLE
PyMySQL SQL Injection vulnerability HotFix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ packaging==23.2
 pandas==2.2.0
 pillow==10.2.0
 plotly==5.19.0
-PyMySQL==1.1.0
+PyMySQL==1.1.1
 pynvim==0.5.0
 python-dateutil==2.8.2
 python-dotenv==1.0.1


### PR DESCRIPTION
PyMySQL through 1.1.0 allows SQL injection if used with untrusted JSON input because keys are not escaped by escape_dict. PyMySQL upgraded to 1.1.1